### PR TITLE
IsGreaterThan/IsLessThan fails with null values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nebula Core
 
- - Paste this onto the end of your My Domain URL: /packaging/installPackage.apexp?p0=04t6M000000gb7IQAQ
- - Include in your SFDX project as `"Nebula Core": "04t6M000000gb7IQAQ"`
+ - Paste this onto the end of your My Domain URL: /packaging/installPackage.apexp?p0=04tQB000000FUx3YAG
+ - Include in your SFDX project as `"Nebula Core": "04tQB000000FUx3YAG"`
  
 The base set of classes used by Nebula Consulting. The licence for this code is MIT, see [LICENSE](LICENSE). 
 

--- a/force-app/lazyIterator/classes/IsFunctionTest.cls
+++ b/force-app/lazyIterator/classes/IsFunctionTest.cls
@@ -75,6 +75,24 @@ private class IsFunctionTest {
                 .toList(new List<Account>());
 
         System.assertEquals(0, result.size());
+
+        result = new LazySObjectIterator(accounts)
+                .put(Account.NumberOfEmployees, null)
+                .filter(new IsLessThan(Account.NumberOfEmployees, 2))
+                .toList(new List<Account>());
+
+        System.assertEquals(2, result.size());
+
+        Integer nullInteger;
+
+        result = new LazySObjectIterator(accounts)
+                .put(Account.NumberOfEmployees, null)
+                .filter(new IsLessThan(Account.NumberOfEmployees, nullInteger))
+                .toList(new List<Account>());
+
+        System.assertEquals(0, result.size());
+
+
     }
 
     @IsTest
@@ -99,6 +117,22 @@ private class IsFunctionTest {
                 .toList(new List<Account>());
 
         System.assertEquals(0, result.size());
+
+        result = new LazySObjectIterator(accounts)
+                .put(Account.NumberOfEmployees, null)
+                .filter(new IsGreaterThan(Account.NumberOfEmployees, 1))
+                .toList(new List<Account>());
+
+        System.assertEquals(0, result.size());
+
+        Integer nullInteger;
+        result = new LazySObjectIterator(accounts)
+                .put(Account.NumberOfEmployees, null)
+                .filter(new IsGreaterThan(new FieldFromSObject(Account.NumberOfEmployees), nullInteger))
+                .toList(new List<Account>());
+
+        System.assertEquals(0, result.size());
+
     }
 
     @IsTest
@@ -109,6 +143,21 @@ private class IsFunctionTest {
 
         System.assertEquals(1, result.size());
         System.assertEquals(events[1].Id, result[0].Id);
+
+        result = new LazySObjectIterator(events)
+                .put(Event.ActivityDate, null)
+                .filterT(new IsGreaterThan(Event.ActivityDate, Event.RecurrenceEndDateOnly))
+                .toList();
+
+        System.assertEquals(0, result.size());
+
+        result = new LazySObjectIterator(events)
+                .put(Event.ActivityDate, Date.today())
+                .put(Event.RecurrenceEndDateOnly, null)
+                .filterT(new IsGreaterThan(Event.ActivityDate, Event.RecurrenceEndDateOnly))
+                .toList();
+
+        System.assertEquals(3, result.size());
 
     }
 

--- a/force-app/lazyIterator/classes/IsGreaterThan.cls
+++ b/force-app/lazyIterator/classes/IsGreaterThan.cls
@@ -29,6 +29,12 @@ global class IsGreaterThan implements BooleanFunction {
         Object leftValue = functions.functions[0].call(o);
         Object rightValue = functions.functions[1].call(o);
 
+        if (leftValue == null) {
+            return false;
+        } else if (rightValue == null) {
+            return true;
+        }
+
         if(leftValue instanceof String) {
             return (String)leftValue > (String)rightValue;
         } else if (leftValue instanceof Integer) {

--- a/force-app/lazyIterator/classes/IsLessThan.cls
+++ b/force-app/lazyIterator/classes/IsLessThan.cls
@@ -29,6 +29,10 @@ global class IsLessThan implements BooleanFunction {
         Object leftValue = functions.functions[0].call(o);
         Object rightValue = functions.functions[1].call(o);
 
+        if (leftValue == null) {
+            return rightValue != null;
+        }
+
         if(leftValue instanceof String) {
             return (String)leftValue < (String)rightValue;
         } else if (leftValue instanceof Integer) {


### PR DESCRIPTION
Allow left/right hand params to be null which is likely with SObjectField values.