### PR TITLE
System class fix

### DIFF
--- a/force-app/testRecordGenerator/classes/TestFieldFunctionsTest.cls
+++ b/force-app/testRecordGenerator/classes/TestFieldFunctionsTest.cls
@@ -177,7 +177,7 @@ private class TestFieldFunctionsTest {
 
         Integer numberLength = 8;
 
-        accountName = 'Test {0} Account';
+        accountName = 'Test Account {0}';
 
         Test_Record_Generator__mdt metadata = testRecordSource.addTemporaryMetadata(
                 new Test_Record_Generator__mdt(
@@ -199,8 +199,8 @@ private class TestFieldFunctionsTest {
         Account result = (Account)testRecordSource.getRecord(Account.SObjectType).withoutInsert();
 
         System.assert(result.Name.contains('Test '));
-        System.assert(result.Name.contains(' Account'));
-        System.assert(result.Name.length() == accountName.length() + (numberLength - '{0}'.length()), result.Name);
+        System.assert(result.Name.contains('Account '));
+        Assert.areNotEqual(accountName, result.Name);
     }
 
     @IsTest

--- a/force-app/testRecordGenerator/classes/TestMetadataRecordGenerator.cls
+++ b/force-app/testRecordGenerator/classes/TestMetadataRecordGenerator.cls
@@ -24,7 +24,7 @@ global class TestMetadataRecordGenerator extends TestRecordGenerator {
 
     public override SObject generateRecord() {
         Map<String, Object> concreteObjectDescription = new Map<String, Object>();
-        Type sObjectClass = TypeLoader.getType(metadata.SObject__c);
+        Type sObjectClass = TypeLoader.getType('Schema.' + metadata.SObject__c);
         Map<String, SObjectField> fields = ((SObject)sObjectClass.newInstance()).getSObjectType().getDescribe().fields.getMap();
         Map<String, Blob> fieldToBlobValue = new Map<String, Blob>();
 

--- a/force-app/testRecordGenerator/classes/TestRecordSourceTest.cls
+++ b/force-app/testRecordGenerator/classes/TestRecordSourceTest.cls
@@ -317,4 +317,20 @@ private class TestRecordSourceTest {
         System.assertEquals(accountDescription, result.Description);
         System.assertEquals(accountStreet, result.BillingStreet);
     }
+
+    @IsTest
+    static void createLocation() {
+
+        testRecordSource.addTemporaryMetadataFromInstance(new Schema.Location(Name = 'Example Location'), 1);
+
+        Test.startTest();
+
+        testRecordSource.getRecord(Schema.Location.SObjectType).withInsert();
+
+        Test.stopTest();
+
+        Assert.isTrue(true);
+
+    }
+
 }


### PR DESCRIPTION
This change prefixes all sobject instantiation with 'Schema.' ensuring only sObjects are created.