### PR TITLE
Trigger metadata mocks

### DIFF
--- a/force-app/common/exceptions/MetadataNotFoundException.cls
+++ b/force-app/common/exceptions/MetadataNotFoundException.cls
@@ -1,0 +1,7 @@
+/**
+ * @author samuelf@nebulaconsulting.co.uk
+ * @date 05/03/2025
+ */
+global class MetadataNotFoundException extends Exception {
+
+}

--- a/force-app/common/exceptions/MetadataNotFoundException.cls-meta.xml
+++ b/force-app/common/exceptions/MetadataNotFoundException.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/triggerFramework/classes/MetadataTriggerManager.cls
+++ b/force-app/triggerFramework/classes/MetadataTriggerManager.cls
@@ -21,20 +21,21 @@ global with sharing class MetadataTriggerManager {
     global static List<Trigger_Handler__mdt> mockMetadata;
 
     private SObjectIndex theseTriggers;
-    private static SObjectIndex sObjectTypeNameToEventToTriggerList { get {
-        if (sObjectTypeNameToEventToTriggerList == null) {
-            sObjectTypeNameToEventToTriggerList = new SObjectIndex(Trigger_Handler__mdt.SObject__c, Trigger_Handler__mdt.Event__c)
-                    .putAll(mockMetadata != null ? mockMetadata :
-                            [
-                                    SELECT DeveloperName, NamespacePrefix, Event__c, SObject__c, Apex_Class__c, Order__c,
-                                            Parameters__c
-                                    FROM Trigger_Handler__mdt
-                                    WHERE Active__c = TRUE
-                                    ORDER BY Order__c ASC
-                            ]);
-        }
-        return sObjectTypeNameToEventToTriggerList;
-    } set;}
+    private static SObjectIndex sObjectTypeNameToEventToTriggerList {
+        get {
+            if (sObjectTypeNameToEventToTriggerList == null) {
+                sObjectTypeNameToEventToTriggerList = new SObjectIndex(Trigger_Handler__mdt.SObject__c, Trigger_Handler__mdt.Event__c, Trigger_Handler__mdt.DeveloperName)
+                        .putAll(mockMetadata != null ? mockMetadata : [
+                                SELECT DeveloperName, NamespacePrefix, Event__c, SObject__c, Apex_Class__c, Order__c,
+                                        Parameters__c
+                                FROM Trigger_Handler__mdt
+                                WHERE Active__c = TRUE
+                                ORDER BY Order__c ASC
+                        ]);
+            }
+            return sObjectTypeNameToEventToTriggerList;
+        } set;
+    }
 
     global MetadataTriggerManager(SObjectType objectType) {
         String sObjectName = objectType.getDescribe().getName();
@@ -96,5 +97,30 @@ global with sharing class MetadataTriggerManager {
                 handleInstance(handlerInstance, triggerOperation, oldList, newList);
             }
         }
+    }
+
+    global static Map<String, Object> getTriggerHandlerParameters(String developerName) {
+        Trigger_Handler__mdt handlerMetadata = getHandlerMetadata(developerName);
+        return (Map<String, Object>) JSON.deserializeUntyped(handlerMetadata.Parameters__c);
+    }
+
+    global static void setTriggerHandlerParameters(String developerName, Map<String, Object> parameters) {
+        setTriggerHandlerParameters(developerName, JSON.serialize(parameters));
+    }
+
+    global static void setTriggerHandlerParameters(String developerName, String parameters) {
+        getHandlerMetadata(developerName).Parameters__c = parameters;
+    }
+
+    private static Trigger_Handler__mdt getHandlerMetadata(String developerName){
+        Trigger_Handler__mdt handlerMetadata = (Trigger_Handler__mdt) sObjectTypeNameToEventToTriggerList.get(new Map<String, Object>{
+                'DeveloperName' => developerName
+        });
+
+        if(handlerMetadata == null){
+            throw new MetadataNotFoundException('Handler metadata "' + developerName + '" was not found');
+        }
+
+        return handlerMetadata;
     }
 }

--- a/force-app/triggerFramework/classes/MetadataTriggerManagerTest.cls
+++ b/force-app/triggerFramework/classes/MetadataTriggerManagerTest.cls
@@ -149,4 +149,88 @@ private class MetadataTriggerManagerTest {
         manager.handle(TriggerOperation.AFTER_UPDATE, contactList, contactList);
         // no result
     }
+
+    @IsTest
+    public static void getsMetadataParameters(){
+        MetadataTriggerManager.mockMetadata = new List<Trigger_Handler__mdt>{
+                new Trigger_Handler__mdt(
+                        Event__c = TriggerOperation.BEFORE_INSERT.name(),
+                        SObject__c = 'Contact',
+                        Apex_Class__c = MetadataTriggerManagerTest.TestHandler.class.getName(),
+                        Order__c = 0,
+                        DeveloperName = 'TestBI',
+                        Parameters__c = JSON.serialize(new Map<String, Object>{
+                                'a' => 'test',
+                                'b' => 'value'
+                        })
+                )
+        };
+
+        Test.startTest();
+
+        Map<String, Object> parameters = MetadataTriggerManager.getTriggerHandlerParameters('TestBI');
+
+        Test.stopTest();
+
+        Assert.areEqual(2, parameters.keySet().size());
+        Assert.areEqual('test', parameters.get('a'));
+        Assert.areEqual('value', parameters.get('b'));
+    }
+
+    @IsTest
+    public static void setsMetadataParameters(){
+        MetadataTriggerManager.mockMetadata = new List<Trigger_Handler__mdt>{
+                new Trigger_Handler__mdt(
+                        Event__c = TriggerOperation.BEFORE_INSERT.name(),
+                        SObject__c = 'Contact',
+                        Apex_Class__c = MetadataTriggerManagerTest.TestHandler.class.getName(),
+                        Order__c = 0,
+                        DeveloperName = 'TestBI',
+                        Parameters__c = JSON.serialize(new Map<String, Object>{
+                                'a' => 'test',
+                                'b' => 'value'
+                        })
+                )
+        };
+
+        Test.startTest();
+
+        MetadataTriggerManager.setTriggerHandlerParameters('TestBI', new Map<String, Object>{
+                        'c' => 'other'
+                }
+        );
+
+        Test.stopTest();
+
+        Map<String, Object> parameters = MetadataTriggerManager.getTriggerHandlerParameters('TestBI');
+
+        Assert.areEqual(1, parameters.size());
+        Assert.areEqual('other', parameters.get('c'));
+        Assert.isFalse(parameters.containsKey('a'));
+        Assert.isFalse(parameters.containsKey('b'));
+    }
+
+    @IsTest
+    public static void cannotFindMetadata(){
+        MetadataTriggerManager.mockMetadata = new List<Trigger_Handler__mdt>{
+                new Trigger_Handler__mdt(
+                        Event__c = TriggerOperation.BEFORE_INSERT.name(),
+                        SObject__c = 'Contact',
+                        DeveloperName = 'TestBI',
+                        Apex_Class__c = MetadataTriggerManagerTest.TestHandler.class.getName(),
+                        Order__c = 0
+                )
+        };
+
+        Test.startTest();
+
+        try {
+            MetadataTriggerManager.getTriggerHandlerParameters('TestBU');
+            Assert.fail();
+        } catch (MetadataNotFoundException e) {
+            Assert.isTrue(e.getMessage().contains('Handler metadata "TestBU" was not found'));
+        }
+
+        Test.stopTest();
+    }
 }


### PR DESCRIPTION
Adding methods for getting/setting parameters of nebc__Trigger_Handler__mdt.

Highlights:
- Metadata is get/set using the developer name as the unique key for precisely selecting the correct record. 
- Parameters are returned as a Map<String, Object> and can be set via a Map<String, Object> or a JSON string.
- A new exception type 'MetadataNotFoundException' is thrown if there is no nebc__Trigger_Handler__mdt record with the specified developer name.

Example Get:
```
Map<String, Object> parameters = MetadataTriggerManager.getTriggerHandlerParameters('MyExampleClassBI');
List<String> validStatuses = parameters.get('validStatuses');
```

Example Set:
```
String newParameters = '{"validStatuses": ["Closed Won","Closed Lost"]}';
MetadataTriggerManager.setTriggerHandlerParameters('MyExampleClassBI', newParameters);
```